### PR TITLE
Successful SMTP responses

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -92,8 +92,10 @@ func Example_newsletter() {
 		m.SetHeader("Subject", "Newsletter #1")
 		m.SetBody("text/html", fmt.Sprintf("Hello %s!", r.Name))
 
-		if err := gomail.Send(s, m); err != nil {
+		if err := gomail.SendSingle(s, m); gomail.IsErr(err) {
 			log.Printf("Could not send email to %q: %v", r.Address, err)
+		} else {
+			log.Print("address", r.Address, "response", err.(gomail.NoError).Response)
 		}
 		m.Reset()
 	}

--- a/send.go
+++ b/send.go
@@ -35,7 +35,7 @@ func (f SendFunc) Send(from string, to []string, msg io.WriterTo) error {
 // Send sends emails using the given Sender.
 func Send(s Sender, msg ...*Message) error {
 	for i, m := range msg {
-		if err := send(s, m); err != nil {
+		if err := SendSingle(s, m); IsErr(err) {
 			return fmt.Errorf("gomail: could not send email %d: %v", i+1, err)
 		}
 	}
@@ -43,7 +43,7 @@ func Send(s Sender, msg ...*Message) error {
 	return nil
 }
 
-func send(s Sender, m *Message) error {
+func SendSingle(s Sender, m *Message) error {
 	from, err := m.getFrom()
 	if err != nil {
 		return err
@@ -54,11 +54,7 @@ func send(s Sender, m *Message) error {
 		return err
 	}
 
-	if err := s.Send(from, to, m); err != nil {
-		return err
-	}
-
-	return nil
+	return s.Send(from, to, m)
 }
 
 func (m *Message) getFrom() (string, error) {

--- a/smtp.go
+++ b/smtp.go
@@ -171,7 +171,8 @@ func (c *smtpSender) Send(from string, to []string, msg io.WriterTo) error {
 	}
 
 	r := &smtpRecorder{&bytes.Buffer{}}
-	defer r.Record(c)()
+	done := r.Record(c)
+	defer done()
 
 	if _, err = msg.WriteTo(w); err != nil {
 		w.Close()

--- a/smtp.go
+++ b/smtp.go
@@ -1,11 +1,14 @@
 package gomail
 
 import (
+	"bufio"
+	"bytes"
 	"crypto/tls"
 	"fmt"
 	"io"
 	"net"
 	"net/smtp"
+	"net/textproto"
 	"strings"
 )
 
@@ -167,12 +170,67 @@ func (c *smtpSender) Send(from string, to []string, msg io.WriterTo) error {
 		return err
 	}
 
+	r := &smtpRecorder{&bytes.Buffer{}}
+	defer r.Record(c)()
+
 	if _, err = msg.WriteTo(w); err != nil {
 		w.Close()
 		return err
 	}
 
-	return w.Close()
+	if err := w.Close(); err != nil {
+		return err
+	}
+
+	return NoError{r.StatusMessage()}
+}
+
+func IsErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, ok := err.(NoError)
+	return !ok
+}
+
+type NoError struct {
+	Response string
+}
+
+func (err NoError) Error() string {
+	return err.Response
+}
+
+type smtpRecorder struct {
+	*bytes.Buffer
+}
+
+func (r *smtpRecorder) Close() error {
+	r.Reset()
+	return nil
+}
+
+func (r *smtpRecorder) Record(c *smtpSender) (done func()) {
+	sc, ok := c.smtpClient.(*smtp.Client)
+	if !ok {
+		return func() {}
+	}
+
+	original := sc.Text.Reader.R
+	sc.Text.Reader.R = bufio.NewReader(io.TeeReader(original, r))
+
+	return func() { sc.Text.Reader.R = original }
+}
+
+func (r *smtpRecorder) StatusMessage() string {
+	if r.Len() == 0 {
+		return ""
+	}
+
+	t := textproto.NewConn(r)
+	defer t.Close()
+	_, statusMsg, _ := t.ReadResponse(250)
+	return statusMsg
 }
 
 func (c *smtpSender) Close() error {


### PR DESCRIPTION
Hack the smtpSender to copy the smtp servers responses into a buffer. Then, after mails have been sent, parse the SMTP response from that buffer.

This enables us to extract SES message IDs from that response.

> Ok 0102015502275713-e7d62a1e-c407-40b9-962f-4d8b43e0e81a-000000

This breaks the interface by making `smtpSender.Send` always return an error. If a message has been sent successfully, it will be of type `gomail.NoError`. `gomail.IsErr(error)` can be used by client code instead of `err != nil` checks.

`gomail.Send` and `gomail.DialAndSend` will continue to return nil if all messages have been sent successfully. Client code that is interested in the response should use `gomail.SendSingle` instead, which may return `gomail.NoError`.
